### PR TITLE
Quick and dirty fix to get the notification service started

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,2 @@
-import uvicorn
-
-from app.main import notif_app
-
-if __name__ == "__main__":
-    uvicorn.run(notif_app, host="0.0.0.0")
+import os
+os.system('uvicorn app.main:notif_app --host 0.0.0.0')


### PR DESCRIPTION
The existing script fails to start (On my machine and OpenShift)  with:
```
[theute@linux-2 custom-policies-notifications]$ python app.py 
INFO:     Started server process [364526]
INFO:     Waiting for application startup.
ERROR:    Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/starlette/routing.py", line 473, in __call__
    await self.startup()
  File "/usr/local/lib/python3.6/site-packages/starlette/routing.py", line 457, in startup
    await handler()
  File "/home/theute/Projects/custom-policies/custom-policies-notifications/app/main.py", line 67, in startup_event
    await consumer.start()
  File "/home/theute/Projects/custom-policies/custom-policies-notifications/app/events/consume.py", line 26, in start
    await self.consumer.start()
  File "/usr/local/lib64/python3.6/site-packages/aiokafka/consumer/consumer.py", line 336, in start
    yield from self._client.bootstrap()
  File "/usr/local/lib64/python3.6/site-packages/aiokafka/client.py", line 200, in bootstrap
    version_hint=version_hint)
  File "/usr/local/lib64/python3.6/site-packages/aiokafka/conn.py", line 89, in create_conn
    yield from conn.connect()
  File "/usr/local/lib64/python3.6/site-packages/aiokafka/conn.py", line 201, in connect
    loop=loop, timeout=self._request_timeout)
  File "/usr/lib64/python3.6/asyncio/tasks.py", line 351, in wait_for
    yield from waiter
RuntimeError: Task <Task pending coro=<LifespanOn.main() running at /usr/local/lib/python3.6/site-packages/uvicorn/lifespan/on.py:48>> got Future <Future pending> attached to a different loop

ERROR:    Application startup failed. Exiting.
[theute@linux-2 custom-policies-notifications]$ 
```

So I'm doing a system call for now...