### PR TITLE
Allow to export subscribers

### DIFF
--- a/app/db/subscriptions.py
+++ b/app/db/subscriptions.py
@@ -35,3 +35,8 @@ async def get_subscribers(account_id: str, event_type: str):
                                                                           (EmailSubscription.event_type == event_type)) \
         .gino.all()
     return emails
+
+
+async def get_all_subscribers():
+    emails: List[EmailSubscription] = await EmailSubscription.query.gino.all()
+    return emails

--- a/app/models/endpoints.py
+++ b/app/models/endpoints.py
@@ -74,6 +74,16 @@ class Settings(BaseModel):
     policies_instant_mail: bool = Field(None, alias='policies-instant-mail')
 
 
+class EmailSubscriptionResponse(BaseModel):
+    account_id: str
+    user_id: str
+    event_type: str
+
+    class Config:
+        orm_mode = True
+        allow_population_by_field_name = True
+
+
 class StatusReply(BaseModel):
     status: str
 

--- a/app/routers/endpoints.py
+++ b/app/routers/endpoints.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from starlette.status import HTTP_404_NOT_FOUND, HTTP_400_BAD_REQUEST
 
 from ..core.errors import InvalidInputException
-from ..models.endpoints import Endpoint, EndpointResponse, Settings, StatusReply
+from ..models.endpoints import Endpoint, EndpointResponse, Settings, StatusReply, EmailSubscriptionResponse
 from ..db import endpoints as endpoint_db, subscriptions as sub_db
 from ..db.schemas import EmailSubscription
 from .auth import Credentials, decode_identity_header
@@ -48,6 +48,13 @@ async def update_email_subscriptions(settings: Settings, identity: Credentials =
         elif settings.policies_daily_mail is True:
             await sub_db.add_email_subscription(identity.account_number, identity.username,
                                                 'policies-daily-mail')
+
+
+@endpoints.get("/endpoints/email/subscriptions", response_model=List[EmailSubscriptionResponse])
+async def get_email_subscriptions():
+    subscribers = await sub_db.get_all_subscribers()
+
+    return subscribers
 
 
 @endpoints.get("/endpoints/email/subscription/{event_type}", response_model=StatusReply)


### PR DESCRIPTION
This allows to pull all the email subscribers to allow a migration to `notifications-backend`.

This supposes that `policies-notifications` doesn't have public access and we can give `notifications-backend` access to it.

We would get a response like:

```json
[
   {
      "account_id":"123456",
      "user_id":"jmartine",
      "event_type":"policies-instant-mail"
   },
   {
      "account_id":"123456",
      "user_id":"jmartine",
      "event_type":"policies-daily-mail"
   },
   {
      "account_id":"123456",
      "user_id":"test1",
      "event_type":"policies-daily-mail"
   },
   {
      "account_id":"123456",
      "user_id":"test2",
      "event_type":"policies-daily-mail"
   },
   {
      "account_id":"123456",
      "user_id":"test3",
      "event_type":"policies-instant-mail"
   },
   {
      "account_id":"123456",
      "user_id":"test4",
      "event_type":"policies-instant-mail"
   },
   {
      "account_id":"123456",
      "user_id":"test4",
      "event_type":"policies-daily-mail"
   }
]
```